### PR TITLE
Number format

### DIFF
--- a/assets/live_phone.js
+++ b/assets/live_phone.js
@@ -72,6 +72,12 @@ class LivePhone {
     this.elements.hiddenField().dispatchEvent(changeEvent)
   }
 
+  // This updates the user visible text field with a formatted
+  // version of the typed number, for this country.
+  setFormat({value: phone}) {
+    this.elements.textField().value = phone
+  }
+
   // Move the currently selected country in the country list overlay
   // one up or down
   shiftSelectedCountry(change) {
@@ -223,6 +229,10 @@ class LivePhone {
     // The "change" event should trigger dispatch on the hidden input
     this.setChange = this.setChange.bind(this)
     this.context.handleEvent("change", this.setChange)
+
+    // The "format" event should display the formatted value
+    this.setFormat = this.setFormat.bind(this)
+    this.context.handleEvent("format", this.setFormat)
 
     // This is used to close the overlay on events that happen outside
     // of our liveview component

--- a/example/lib/live_phone_example_web/live/page_live.ex
+++ b/example/lib/live_phone_example_web/live/page_live.ex
@@ -2,7 +2,7 @@ defmodule LivePhoneExampleWeb.PageLive do
   use LivePhoneExampleWeb, :live_view
 
   @impl true
-  def mount(socket) do
+  def mount(_params, _session, socket) do
     {:ok,
      socket
      |> assign(:phone_number, "")

--- a/example/lib/live_phone_example_web/live/page_live.html.leex
+++ b/example/lib/live_phone_example_web/live/page_live.html.leex
@@ -2,7 +2,7 @@
   <h1>LivePhone Demo</h1>
 
   <%= form_tag "#", phx_change: "change", phx_submit: "change" %>
-    <%= live_component(@socket, LivePhone.Component, value: "+14242424242", id: "phone", form: :user, field: :phone, preferred: ["US", "GB", "CA"]) %>
+    <%= live_component(@socket, LivePhone.Component, id: "phone", form: :user, field: :phone, preferred: ["US", "GB", "CA"], placeholder: "Phone") %>
   </form>
 </section>
 

--- a/lib/live_phone/component.ex
+++ b/lib/live_phone/component.ex
@@ -90,9 +90,11 @@ defmodule LivePhone.Component do
     socket =
       with true <- is_valid?,
            {:ok, country} <- LivePhone.get_country(value) do
+        without_country_code = String.replace(formatted_value, "+#{country.region_code}", "")
+
         socket
         |> assign(:country, country.code)
-        |> assign(:value, String.replace(formatted_value, "+#{country.region_code}", ""))
+        |> assign(:value, without_country_code)
       else
         _ -> socket |> assign(:value, value)
       end
@@ -115,11 +117,19 @@ defmodule LivePhone.Component do
   def handle_event("select_country", %{"country" => country}, socket) do
     is_valid? = LivePhone.is_valid?(socket.assigns[:formatted_value])
 
+    placeholder =
+      if socket.assigns[:country] == country do
+        socket.assigns[:placeholder]
+      else
+        get_placeholder(country)
+      end
+
     {:noreply,
      socket
      |> assign_country(country)
      |> assign(:is_valid?, is_valid?)
      |> assign(:is_opened?, false)
+     |> assign(:placeholder, placeholder)
      |> push_event("focus", %{})}
   end
 

--- a/lib/live_phone/component.ex
+++ b/lib/live_phone/component.ex
@@ -100,6 +100,7 @@ defmodule LivePhone.Component do
       end
 
     socket
+    |> format_user_input(formatted_value)
     |> assign(:is_valid?, is_valid?)
     |> assign(:formatted_value, formatted_value)
     |> push_event("change", %{value: formatted_value})
@@ -168,6 +169,56 @@ defmodule LivePhone.Component do
   defp assign_country(socket, country) do
     socket
     |> assign(:country, country)
+  end
+
+  @spec format_user_input(Phoenix.LiveView.Socket.t(), String.t()) :: Phoenix.LiveView.Socket.t()
+  defp format_user_input(socket, ""), do: socket
+  defp format_user_input(socket, "0"), do: socket
+  defp format_user_input(socket, "00"), do: socket
+
+  defp format_user_input(
+         %{assigns: %{formatted_value: formatted_value}} = socket,
+         formatted_value
+       ),
+       do: socket
+
+  defp format_user_input(socket, formatted_value) do
+    with {:ok, country} <- Countries.get_country(socket.assigns[:country]),
+         country_placeholder <- get_placeholder(country.code) do
+      without_country_code =
+        formatted_value
+        |> String.replace("+#{country.region_code}", "")
+        |> String.replace(~r/[^0-9]+/, "")
+        |> String.replace(~r/^0+/, "")
+
+      country_placeholder =
+        country_placeholder
+        |> String.replace(~r/[^0-9]+/, " ")
+        |> String.replace(~r/^0+/, "")
+        |> String.trim()
+
+      {number, remain} =
+        Enum.map_reduce(
+          to_charlist(country_placeholder),
+          to_charlist(without_country_code),
+          fn
+            ?5, [first | digits] -> {first, digits}
+            ?5, [] = digits -> {'•', digits}
+            other, digits -> {other, digits}
+          end
+        )
+
+      user_formatted =
+        [number, remain]
+        |> List.flatten()
+        |> to_string
+        |> String.replace(~r/(•.*)/, "")
+
+      socket
+      |> push_event("format", %{value: user_formatted})
+    else
+      _ -> socket
+    end
   end
 
   @spec phone_input(Phoenix.LiveView.Socket.assigns()) :: Phoenix.HTML.Safe.t()

--- a/lib/live_phone/component.ex
+++ b/lib/live_phone/component.ex
@@ -43,6 +43,7 @@ defmodule LivePhone.Component do
      socket
      |> assign_new(:preferred, fn -> ["US", "GB"] end)
      |> assign_new(:tabindex, fn -> 0 end)
+     |> assign_new(:apply_format?, fn -> false end)
      |> assign_new(:value, fn -> "" end)
      |> assign(:is_opened?, false)
      |> assign(:is_valid?, false)}
@@ -172,6 +173,7 @@ defmodule LivePhone.Component do
   end
 
   @spec format_user_input(Phoenix.LiveView.Socket.t(), String.t()) :: Phoenix.LiveView.Socket.t()
+  defp format_user_input(%{assigns: %{apply_format?: false}} = socket, _), do: socket
   defp format_user_input(socket, ""), do: socket
   defp format_user_input(socket, "0"), do: socket
   defp format_user_input(socket, "00"), do: socket

--- a/lib/live_phone/countries.ex
+++ b/lib/live_phone/countries.ex
@@ -37,6 +37,30 @@ defmodule LivePhone.Countries do
   end
 
   @doc """
+  This function will lookup a `Country` by it's country code.
+
+  ```elixir
+  Examples:
+
+    iex> LivePhone.Countries.get_country("US")
+    {:ok, %LivePhone.Country{code: "US", flag_emoji: "🇺🇸", name: "United States of America (the)", preferred: false, region_code: "1"}}
+
+    iex> LivePhone.Countries.get_country("FAKE")
+    {:error, :not_found}
+
+  ```
+  """
+  @spec get_country(String.t()) :: {:ok, Country.t()} | {:error, :not_found}
+  def get_country(country_code) do
+    list_countries()
+    |> Enum.find(&(&1.code == country_code))
+    |> case do
+      nil -> {:error, :not_found}
+      country -> {:ok, country}
+    end
+  end
+
+  @doc """
   This function can be used to try and find the `Country` for a specific
   phone number in the `ExPhoneNumber` format.
   """

--- a/test/live_phone/component_test.exs
+++ b/test/live_phone/component_test.exs
@@ -182,6 +182,44 @@ defmodule LivePhone.ComponentTest do
     assert view |> element("div.live_phone-country") |> render() =~ "🇬🇧 +44"
   end
 
+  test "change placeholder on select country", %{conn: conn} do
+    {:ok, view, _html} = live(conn, "/")
+
+    # Placeholder is "Phone" by default
+    assert view |> element(".live_phone-input[placeholder=Phone]") |> has_element?()
+
+    # Click the country button
+    assert view |> element("div.live_phone-country") |> render_click()
+
+    # Yes country list
+    assert view |> element("ul.live_phone-country-list") |> has_element?()
+
+    # Click Great Britain
+    assert view |> element("li[phx-value-country=\"GB\"]") |> render_click()
+
+    # Placeholder should change to example number
+    assert view |> element(".live_phone-input[placeholder='055 5555 5555']") |> has_element?()
+  end
+
+  test "change placeholder on select country (unless same country)", %{conn: conn} do
+    {:ok, view, _html} = live(conn, "/")
+
+    # Placeholder is "Phone" by default
+    assert view |> element(".live_phone-input[placeholder=Phone]") |> has_element?()
+
+    # Click the country button
+    assert view |> element("div.live_phone-country") |> render_click()
+
+    # Yes country list
+    assert view |> element("ul.live_phone-country-list") |> has_element?()
+
+    # Click Great Britain
+    assert view |> element("li[phx-value-country=\"US\"]") |> render_click()
+
+    # Placeholder should change to example number
+    assert view |> element(".live_phone-input[placeholder=Phone]") |> has_element?()
+  end
+
   test "close country list on input blur", %{conn: conn} do
     {:ok, view, _html} = live(conn, "/")
 

--- a/test/live_phone/component_test.exs
+++ b/test/live_phone/component_test.exs
@@ -253,7 +253,7 @@ defmodule LivePhone.ComponentTest do
   end
 
   test "reformat while typing", %{conn: conn} do
-    {:ok, view, _html} = live(conn, "/")
+    {:ok, view, _html} = live(conn, "/?format=1")
 
     assert view |> element(".live_phone-input") |> render_keyup(%{"value" => "424242"})
     assert_push_event(view, "format", %{value: "424 242 "})
@@ -268,7 +268,7 @@ defmodule LivePhone.ComponentTest do
   end
 
   test "reformat while typing (ignore empty value)", %{conn: conn} do
-    {:ok, view, _html} = live(conn, "/")
+    {:ok, view, _html} = live(conn, "/?format=1")
 
     assert view |> element(".live_phone-input") |> render_keyup(%{"value" => ""})
     refute_push_event(view, "format", %{value: ""})
@@ -281,12 +281,19 @@ defmodule LivePhone.ComponentTest do
   end
 
   test "reformat while typing (ignore same value)", %{conn: conn} do
-    {:ok, view, _html} = live(conn, "/")
+    {:ok, view, _html} = live(conn, "/?format=1")
 
     assert view |> element(".live_phone-input") |> render_keyup(%{"value" => "+1 (650) 253-0000"})
     assert_push_event(view, "format", %{value: "650 253 0000"})
 
     assert view |> element(".live_phone-input") |> render_keyup(%{"value" => "+16502530000"})
+    refute_push_event(view, "format", %{value: "650 253 0000"})
+  end
+
+  test "dont reformat if [apply_format?: false] ", %{conn: conn} do
+    {:ok, view, _html} = live(conn, "/")
+
+    assert view |> element(".live_phone-input") |> render_keyup(%{"value" => "+1 (650) 253-0000"})
     refute_push_event(view, "format", %{value: "650 253 0000"})
   end
 

--- a/test/support/test_endpoint.ex
+++ b/test/support/test_endpoint.ex
@@ -14,6 +14,7 @@ defmodule LivePhoneTestApp do
         id: "phone",
         form: :user,
         field: :phone,
+        placeholder: "Phone",
         preferred: ["US", "GB", "CA"]
       ) %>
       """

--- a/test/support/test_endpoint.ex
+++ b/test/support/test_endpoint.ex
@@ -6,6 +6,17 @@ defmodule LivePhoneTestApp do
     use Phoenix.LiveView
 
     @impl true
+    def handle_params(%{"format" => "1"}, _session, socket) do
+      {:noreply,
+       socket
+       |> assign(apply_format?: true)}
+    end
+
+    def handle_params(_params, _session, socket) do
+      {:noreply, socket}
+    end
+
+    @impl true
     def render(assigns) do
       ~L"""
       <%= live_component(
@@ -14,6 +25,7 @@ defmodule LivePhoneTestApp do
         id: "phone",
         form: :user,
         field: :phone,
+        apply_format?: assigns[:apply_format?] == true,
         placeholder: "Phone",
         preferred: ["US", "GB", "CA"]
       ) %>
@@ -32,6 +44,15 @@ defmodule LivePhoneTestApp do
 
   defmodule Endpoint do
     use Phoenix.Endpoint, otp_app: :live_phone
+
+    plug(Plug.Parsers,
+      parsers: [:urlencoded, :multipart, :json],
+      pass: ["*/*"],
+      body_reader: {BasicSpaceWeb.Plugs.CacheBodyReader, :read_body, []},
+      json_decoder: Jason,
+      length: 100_000_000
+    )
+
     plug(Router)
   end
 


### PR DESCRIPTION
This PR is an attempt to resolve two issues, see below.

I'm not sure the reformatting is that great of an experience, so I put it behind a flag `apply_format?` which should be set to `true` if you want this functionality to work. Defaults to `false`. It's only formatting with spaces, not any other additional characters like `()-`. That made the experience pretty bad I discovered while building this functionality.

- Fixes https://github.com/whitepaperclip/live_phone/issues/2
- Fixes https://github.com/whitepaperclip/live_phone/issues/3