### PR TITLE
input pattern should support space

### DIFF
--- a/example/lib/live_phone_example_web/live/page_live.html.leex
+++ b/example/lib/live_phone_example_web/live/page_live.html.leex
@@ -2,7 +2,7 @@
   <h1>LivePhone Demo</h1>
 
   <%= form_tag "#", phx_change: "change", phx_submit: "change" %>
-    <%= live_component(@socket, LivePhone.Component, id: "phone", form: :user, field: :phone, preferred: ["US", "GB", "CA"], placeholder: "Phone") %>
+    <%= live_component(@socket, LivePhone.Component, id: "phone", form: :user, field: :phone, preferred: ["US", "GB", "CA"], apply_format?: true, placeholder: "Phone") %>
   </form>
 </section>
 

--- a/lib/live_phone/component.ex
+++ b/lib/live_phone/component.ex
@@ -225,6 +225,8 @@ defmodule LivePhone.Component do
     tag(:input,
       type: "tel",
       class: "live_phone-input",
+      pattern: "[0-9 ]*",
+      inputmode: "numeric",
       value: assigns[:value],
       tabindex: assigns[:tabindex],
       placeholder: assigns[:placeholder] || get_placeholder(assigns[:country]),


### PR DESCRIPTION
The browser will reject numbers with spaces, which is exactly the format that the built-in auto formatting will put into the input field. So with auto formatting enabled it currently doesn't work as expected, the browser will complain the value doesn't match the required pattern.