### PR TITLE
fix bug where the country sometimes gets reset

### DIFF
--- a/assets/live_phone.js
+++ b/assets/live_phone.js
@@ -69,6 +69,7 @@ class LivePhone {
   // back-end. So this sends a dummy change event to work around it.
   setChange({value: phone}) {
     const changeEvent = new Event('change', {bubbles: true})
+    this.elements.hiddenField().value = phone
     this.elements.hiddenField().dispatchEvent(changeEvent)
   }
 

--- a/test/live_phone/component_test.exs
+++ b/test/live_phone/component_test.exs
@@ -297,11 +297,31 @@ defmodule LivePhone.ComponentTest do
     refute_push_event(view, "format", %{value: "650 253 0000"})
   end
 
+  test "country should persist", %{conn: conn} do
+    {:ok, view, _html} = live(conn, "/?format=1")
+
+    # Set country to GB
+    assert view |> element("div.live_phone-country") |> render_click()
+    assert view |> element("li[phx-value-country=\"JP\"]") |> render_click()
+
+    # Type number
+    assert view |> element(".live_phone-input") |> render_keyup(%{"value" => "9020943029"})
+    assert view |> element("div.live_phone-country") |> render() =~ "🇯🇵 +81"
+    assert view |> trigger_update()
+    assert view |> element("div.live_phone-country") |> render() =~ "🇯🇵 +81"
+  end
+
   # NOTE: This function does not exist by itself so I just copied and changed the
   # built-in assert_push_event from LiveView for this purpose.
   defp refute_push_event(view, event, payload, timeout \\ 100) do
     %{proxy: {ref, _topic, _}} = view
 
     refute_receive {^ref, {:push_event, ^event, ^payload}}, timeout
+  end
+
+  # This function is use to trigger the "update" callback on the component,
+  # it just increments a test counter assign that is not used anywhere else.
+  defp trigger_update(view) do
+    view |> element("#test_incr") |> render_click()
   end
 end

--- a/test/support/test_endpoint.ex
+++ b/test/support/test_endpoint.ex
@@ -27,9 +27,17 @@ defmodule LivePhoneTestApp do
         field: :phone,
         apply_format?: assigns[:apply_format?] == true,
         placeholder: "Phone",
-        preferred: ["US", "GB", "CA"]
+        preferred: ["US", "GB", "CA"],
+        test_counter: assigns[:test_counter]
       ) %>
+
+      <button id="test_incr" phx-click="incr" />
       """
+    end
+
+    def handle_event("incr", _params, socket) do
+      current = (socket.assigns[:test_counter] || 0) + 1
+      {:noreply, assign(socket, test_counter: current)}
     end
   end
 


### PR DESCRIPTION
When you are using the component without setting the current `country` value manually, it should keep the current country selection or use a preferred one. However, keeping the current country was not working correctly as it only checked the new `assigns` and not the current `assigns`. This PR adds a test that failed before the fix was added.

The JS change is to ensure that the correct value is set when the component lets the form know the input value changed. This was not really part of the bugfix but I noticed it was missing.

