### PR TITLE
Clear input and formatting bugfix

### DIFF
--- a/assets/live_phone.js
+++ b/assets/live_phone.js
@@ -113,7 +113,11 @@ class LivePhone {
 
     // Find all typed digits
     let digits = digitsOnly(this.elements.textField().value)
-    if (!digits.length) return
+    if (!digits.length) {
+      this.elements.textField().value = ''
+      this.elements.hiddenField().value = ''
+      return
+    }
 
     // Find the best-match mask based on digit and mask lengths
     let [currentMask] = this.masks

--- a/assets/live_phone.js
+++ b/assets/live_phone.js
@@ -129,7 +129,12 @@ class LivePhone {
         if (sizeA > sizeB) return 1
         return 0
       })
-    if (!currentMask) return
+    if (!currentMask) {
+      let digitsString = digits.join('')
+      this.elements.textField().value = digitsString
+      this.elements.hiddenField().value = digitsString
+      return
+    }
 
     // Replace the mask letters with digits
     let value = currentMask.replace(/[X]/g, match => {


### PR DESCRIPTION
We're currently using this library in our application and noticed a couple of bugs.
- When you clear the input field, no change is made to the hidden field, which is what actually represents the data in the form. When submitting the form after clearing the phone input field, it submits whatever the previous input was (e.g. if you did a select all and backspace, it would submit the entire phone number that was in the field)
- The input field allows letters and maintains a previous mask even if the current value of the input field doesn't match any masks. While the letters and special characters aren't included in the phone number on submit, what the user sees doesn't match what is being submitted (e.g. the user sees `123-456-7890blahblah`, but only `1234567890` is actually submitted)