### PR TITLE
Add strict mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,12 +53,15 @@ Usage is pretty simple, and there is an example Phoenix project included in the 
   field={:phone}
   tabindex={0}
   preferred={["US", "CA"]}
-  phx-debounce="100" />
+  phx-debounce="100"
+  strict />
 ```
 
 This will result in a form field with the name `user[phone]`. You can specify just the `name` manually if desired, but when you add the `form` option the name will be generated via `Phoenix.HTML.Form.input_name/2`. So this should behave like a regular input field.
 
 With `preferred` you can set a list of countries that you believe should be on top always. The currently selected country will also be on top automatically.
+
+With `strict` enabled, the visible input only allows digits and an optional leading `+`. When strict mode is on, visible masking is skipped so the field stays strictly numeric-ish. This keeps the displayed value closer to the normalized value that gets submitted, while preserving the existing permissive behavior by default.
 
 With `phx-debounce`, you can rate limit events affecting the input field, so that you won't send events to your backend everytime the user presses a key stroke. Please refer [https://hexdocs.pm/phoenix_live_view/bindings.html#rate-limiting-events-with-debounce-and-throttle](to your version of LiveView bindings for more information). Sending too many events to your backend may make your UI erratic and slow to respond to users with a lot of latency.
 

--- a/assets/live_phone.js
+++ b/assets/live_phone.js
@@ -55,7 +55,7 @@ class LivePhone {
       this.masks = []
     }
 
-    this.strict = this.elements.textField().dataset.strict === 'true'
+    this.strict = this.elements.textField().hasAttribute('data-strict')
     this.format()
   }
 
@@ -183,7 +183,7 @@ class LivePhone {
     const textField = this.elements.textField()
     if (!textField) return
 
-    this.strict = textField.dataset.strict === 'true'
+    this.strict = textField.hasAttribute('data-strict')
 
     // Update the masks (if there were previous masks set)
     let newMasks = textField.dataset.masks

--- a/assets/live_phone.js
+++ b/assets/live_phone.js
@@ -13,6 +13,16 @@ const maskSize = input =>
   .split('') // turn into array
   .length // return length
 
+const strictValue = input => {
+  if (!input) return ''
+
+  let value = input.replace(/[^0-9+]/g, '')
+  let hasLeadingPlus = value[0] === '+'
+  value = value.replace(/\+/g, '')
+
+  return hasLeadingPlus ? `+${value}` : value
+}
+
 class LivePhone {
   constructor(context) {
     // This contains the original context of the LiveView Hook
@@ -44,6 +54,8 @@ class LivePhone {
     } else {
       this.masks = []
     }
+
+    this.strict = this.elements.textField().dataset.strict === 'true'
     this.format()
   }
 
@@ -109,15 +121,23 @@ class LivePhone {
 
   // Format the visible input field using the best-match mask
   format() {
-    if (!this.masks) return
+    const textField = this.elements.textField()
+    const hiddenField = this.elements.hiddenField()
+    if (!textField) return
+
+    if (this.strict) {
+      textField.value = strictValue(textField.value)
+    }
 
     // Find all typed digits
-    let digits = digitsOnly(this.elements.textField().value)
+    let digits = digitsOnly(textField.value)
     if (!digits.length) {
-      this.elements.textField().value = ''
-      this.elements.hiddenField().value = ''
+      textField.value = this.strict && textField.value[0] === '+' ? '+' : ''
+      if (hiddenField) hiddenField.value = ''
       return
     }
+
+    if (this.strict || !this.masks || !this.masks.length) return
 
     // Find the best-match mask based on digit and mask lengths
     let [currentMask] = this.masks
@@ -129,7 +149,12 @@ class LivePhone {
         if (sizeA > sizeB) return 1
         return 0
       })
-    if (!currentMask) return
+    if (!currentMask) {
+      if (this.strict) {
+        textField.value = strictValue(textField.value)
+      }
+      return
+    }
 
     // Replace the mask letters with digits
     let value = currentMask.replace(/[X]/g, match => {
@@ -145,7 +170,7 @@ class LivePhone {
       value = value.substr(0, lastDigitIndex + 1)
     }
 
-    this.elements.textField().value = value
+    textField.value = value
   }
 
   // While the user typing in the input field we want to auto format it
@@ -155,12 +180,20 @@ class LivePhone {
 
   // When the LiveView component gets updated it will execute this callback
   onUpdate() {
+    const textField = this.elements.textField()
+    if (!textField) return
+
+    this.strict = textField.dataset.strict === 'true'
+
     // Update the masks (if there were previous masks set)
-    let newMasks = this.elements.textField().dataset.masks
-    if (this.masks && newMasks) {
+    let newMasks = textField.dataset.masks
+    if (newMasks) {
       this.masks = newMasks.split(/\s*,\s*/g)
-      this.format()
+    } else {
+      this.masks = []
     }
+
+    this.format()
   }
 
   // Move the currently selected country in the country list overlay

--- a/lib/live_phone.ex
+++ b/lib/live_phone.ex
@@ -18,6 +18,7 @@ defmodule LivePhone do
      |> assign_new(:preferred, fn -> ["US", "GB"] end)
      |> assign_new(:tabindex, fn -> 0 end)
      |> assign_new(:apply_format?, fn -> false end)
+     |> assign_new(:strict, fn -> false end)
      |> assign_new(:value, fn -> "" end)
      |> assign_new(:opened?, fn -> false end)
      |> assign_new(:valid?, fn -> false end)
@@ -68,6 +69,7 @@ defmodule LivePhone do
         tabindex={assigns[:tabindex]}
         placeholder={assigns[:placeholder] || get_placeholder(assigns[:country])}
         data-masks={@masks}
+        data-strict={@strict}
         phx-target={@myself}
         phx-keyup="typing"
         phx-debounce={assigns[:"phx-debounce"]}

--- a/test/live_phone/browser_test.exs
+++ b/test/live_phone/browser_test.exs
@@ -100,5 +100,47 @@ defmodule LivePhone.BrowserTest do
 
       assert value == "650-253-0000"
     end
+
+    feature "strict mode strips non-digit characters", %{session: session} do
+      session =
+        session
+        |> visit(@root_path <> "?strict=1")
+        |> fill_in(Query.css("input.live_phone-input"), with: "212-312-3321ddd")
+
+      value =
+        session
+        |> find(Query.css("input.live_phone-input"))
+        |> Element.attr("value")
+
+      assert value == "2123123321"
+    end
+
+    feature "strict mode allows a leading plus", %{session: session} do
+      session =
+        session
+        |> visit(@root_path <> "?strict=1")
+        |> fill_in(Query.css("input.live_phone-input"), with: "+1 (650) 253-0000")
+
+      value =
+        session
+        |> find(Query.css("input.live_phone-input"))
+        |> Element.attr("value")
+
+      assert value == "+16502530000"
+    end
+
+    feature "strict mode skips visible masking", %{session: session} do
+      session =
+        session
+        |> visit(@root_path <> "?strict=1&format=1")
+        |> fill_in(Query.css("input.live_phone-input"), with: "6502530000")
+
+      value =
+        session
+        |> find(Query.css("input.live_phone-input"))
+        |> Element.attr("value")
+
+      assert value == "6502530000"
+    end
   end
 end

--- a/test/live_phone_test.exs
+++ b/test/live_phone_test.exs
@@ -46,13 +46,13 @@ defmodule LivePhoneTest do
   test "has strict mode disabled by default" do
     component = render_live_phone(id: "livephone")
 
-    assert component =~ "data-strict=\"false\""
+    refute component =~ "data-strict"
   end
 
   test "supports strict mode" do
     component = render_live_phone(id: "livephone", strict: true)
 
-    assert component =~ "data-strict=\"true\""
+    assert component =~ "data-strict"
   end
 
   test "support setting phx-debounce" do

--- a/test/live_phone_test.exs
+++ b/test/live_phone_test.exs
@@ -43,6 +43,18 @@ defmodule LivePhoneTest do
     refute component =~ "phx-debounce"
   end
 
+  test "has strict mode disabled by default" do
+    component = render_live_phone(id: "livephone")
+
+    assert component =~ "data-strict=\"false\""
+  end
+
+  test "supports strict mode" do
+    component = render_live_phone(id: "livephone", strict: true)
+
+    assert component =~ "data-strict=\"true\""
+  end
+
   test "support setting phx-debounce" do
     component = render_live_phone(id: "livephone", "phx-debounce": "blur")
 

--- a/test/support/test_endpoint.ex
+++ b/test/support/test_endpoint.ex
@@ -17,7 +17,10 @@ defmodule LivePhoneTestApp do
 
     @impl true
     def handle_params(params, _session, socket) do
-      {:noreply, socket |> assign(format?: params["format"] == "1")}
+      {:noreply,
+       socket
+       |> assign(format?: params["format"] == "1")
+       |> assign(strict?: params["strict"] == "1")}
     end
 
     @impl true
@@ -32,6 +35,7 @@ defmodule LivePhoneTestApp do
           form={:user}
           field={:phone}
           apply_format?={assigns[:format?]}
+          strict={assigns[:strict?]}
           placeholder="Phone"
           preferred={["US", "GB", "CA"]}
           test_counter={assigns[:test_counter]}


### PR DESCRIPTION
Adds an opt-in `strict` mode to `LivePhone`. When enabled, the visible input allows only digits and an optional leading `+`. Visible masking is skipped in strict mode so the field stays numeric-ish even when `apply_format?` is set. #162 